### PR TITLE
Fix padding not getting generated on empty structures with a size

### DIFF
--- a/include/Genny.hpp
+++ b/include/Genny.hpp
@@ -1216,8 +1216,9 @@ public:
 
         if (!m_children.empty()) {
             os << "public:\n";
-            generate_internal(os);
         }
+
+        generate_internal(os);
 
         os << "}; // Size: 0x" << std::hex << size() << "\n";
     }


### PR DESCRIPTION
Introduced in 708c8b91724328f9fdc426cb4ebe63374bf82afa