### PR TITLE
Recursive parent recursion fix & clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 .DS_Store
 out
 build
-cmake-build-debug
-cmake-build-release
+cmake-build-*/

--- a/include/sdkgenny/constant.hpp
+++ b/include/sdkgenny/constant.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <ostream>
 #include <string>
 
@@ -27,12 +28,12 @@ public:
         return this;
     }
 
-    template <typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true> auto real(T value) {
+    template <std::floating_point T> auto real(T value) {
         m_value = std::to_string(value);
         return this;
     }
 
-    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true> auto integer(T value) {
+    template <std::integral T> auto integer(T value) {
         m_value = std::to_string(value);
         return this;
     }

--- a/include/sdkgenny/sdk.hpp
+++ b/include/sdkgenny/sdk.hpp
@@ -116,9 +116,9 @@ protected:
         std::set<std::filesystem::path> includes{};
 
         if (auto s = dynamic_cast<Struct*>(obj)) {
-            auto deps = s->dependencies();
-            types_to_include = deps.hard;
-            types_to_forward_decl = deps.soft;
+            auto [hard, soft] = s->dependencies();
+            types_to_include = hard;
+            types_to_forward_decl = soft;
         }
 
         for (auto&& ty : types_to_include) {
@@ -133,7 +133,7 @@ protected:
             auto owners = type->owners<Namespace>();
 
             if (owners.size() > 1 && m_generate_namespaces) {
-                std::reverse(owners.begin(), owners.end());
+                std::ranges::reverse(owners);
 
                 os << "namespace ";
 
@@ -249,9 +249,9 @@ protected:
         std::unordered_set<Type*> types_to_include{};
 
         if (auto s = dynamic_cast<Struct*>(obj)) {
-            auto deps = s->dependencies();
-            types_to_include = deps.hard;
-            types_to_include.merge(deps.soft);
+            auto [hard, soft] = s->dependencies();
+            types_to_include = hard;
+            types_to_include.merge(soft);
             types_to_include.emplace(s);
         }
 

--- a/include/sdkgenny/struct.hpp
+++ b/include/sdkgenny/struct.hpp
@@ -42,7 +42,7 @@ public:
     Struct* parent(Struct* parent);
 
     size_t size() const override;
-    auto size(int size) {
+    auto size(size_t size) {
         m_size = size;
         return this;
     }

--- a/include/sdkgenny/variable.hpp
+++ b/include/sdkgenny/variable.hpp
@@ -39,14 +39,12 @@ public:
     auto end() const { return offset() + size(); }
 
     auto bit_size(size_t size) {
-        // assert(size <= m_type->size() * CHAR_BIT);
         m_bit_size = size;
         return this;
     }
     auto bit_size() const { return m_bit_size; }
 
     auto bit_offset(uintptr_t offset) {
-        // assert(offset < m_type->size() * CHAR_BIT);
         m_bit_offset = offset;
         return this;
     }

--- a/src/array.cpp
+++ b/src/array.cpp
@@ -7,7 +7,7 @@ Array::Array(std::string_view name) : Type{name} {
 Array* Array::count(size_t count) {
     // Fix the name of this array type.
     if (m_of != nullptr && count != m_count) {
-        const auto& base = m_of->name();
+        auto& base = m_of->name();
         auto first_brace = base.find_first_of('[');
         auto head = base.substr(0, first_brace);
         std::string tail{};

--- a/src/detail/indent.cpp
+++ b/src/detail/indent.cpp
@@ -18,7 +18,7 @@ Indent::~Indent() {
 
 int Indent::overflow(int ch) {
     if (m_is_at_start_of_line && ch != '\n') {
-        m_dest->sputn(m_indent.data(), m_indent.size());
+        m_dest->sputn(m_indent.data(), static_cast<std::streamsize>(m_indent.size()));
     }
     m_is_at_start_of_line = ch == '\n';
     return m_dest->sputc(static_cast<char>(ch));

--- a/src/enum.cpp
+++ b/src/enum.cpp
@@ -21,9 +21,9 @@ Enum* Enum::value(std::string_view name, uint64_t value) {
 size_t Enum::size() const {
     if (m_type == nullptr) {
         return sizeof(int);
-    } else {
-        return m_type->size();
     }
+
+    return m_type->size();
 }
 
 void Enum::generate_forward_decl(std::ostream& os) const {
@@ -50,8 +50,9 @@ void Enum::generate_enums(std::ostream& os) const {
     detail::Indent _{os};
 
     for (auto&& [name, value] : m_values) {
-        if (!m_type || 1ull << (m_type->size() * 8) > value)
+        if (!m_type || 1ull << (m_type->size() * 8) > value) {
             os << name << " = " << value << ",\n";
+        }
     }
 }
 } // namespace sdkgenny

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -73,7 +73,7 @@ void Function::generate_procedure(std::ostream& os) const {
         owners.emplace_back(o);
     }
 
-    std::reverse(owners.begin(), owners.end());
+    std::ranges::reverse(owners);
 
     for (auto&& o : owners) {
         os << o->usable_name() << "::";

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -42,18 +42,17 @@ void Object::generate_comment(std::ostream& os) const {
 std::unique_ptr<Object> Object::remove(Object* obj) {
     obj->m_owner = nullptr;
 
-    if (auto search = std::find_if(m_children.begin(), m_children.end(), [obj](auto&& c) { return c.get() == obj; });
+    if (auto search = std::ranges::find_if(m_children, [obj](auto&& c) { return c.get() == obj; });
         search != m_children.end()) {
         auto p = std::move(*search);
         m_children.erase(search);
         return p;
     }
-    /* m_children.erase(
-        std::remove_if(m_children.begin(), m_children.end(), [obj](auto&& c) { return c.get() == obj; }));*/
+
     return nullptr;
 }
 
-std::filesystem::path Object::path() {
+std::filesystem::path Object::path() const {
     if (m_owner == nullptr) {
         return usable_name();
     }
@@ -61,7 +60,7 @@ std::filesystem::path Object::path() {
     std::filesystem::path p{};
     auto os = owners<Object>();
 
-    std::reverse(os.begin(), os.end());
+    std::ranges::reverse(os);
 
     for (auto&& o : os) {
         if (o->template is_a<Namespace>()) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -13,7 +13,7 @@ Reference* Type::ref() {
 }
 
 Pointer* Type::ptr() {
-    return (Pointer*)m_owner->find_or_add<Pointer>(name() + '*')->to(this);
+    return reinterpret_cast<Pointer*>(m_owner->find_or_add<Pointer>(name() + '*')->to(this));
 }
 
 Array* Type::array_(size_t count) {


### PR DESCRIPTION
Fix:
* Don't allow classes to inherit themselves.
* Make struct size argument the correct type.
* Check for possible nullptr when generating bitfields.

Clean up code:
* Convert casts to C++-style casts.
* Use ranges library.
* Use concepts library.
* Brace initialize where possible.
* Remove some unused code/assert comments.