### PR TITLE
feat: lazy type resolve for variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 build
 cmake-build-debug
 cmake-build-release
+.cache

--- a/include/sdkgenny/namespace.hpp
+++ b/include/sdkgenny/namespace.hpp
@@ -21,5 +21,7 @@ public:
     Enum* enum_(std::string_view name);
     EnumClass* enum_class(std::string_view name);
     Namespace* namespace_(std::string_view name);
+
+    Type* resolve_type(std::string_view nstype);
 };
 } // namespace sdkgenny

--- a/include/sdkgenny/variable.hpp
+++ b/include/sdkgenny/variable.hpp
@@ -13,7 +13,7 @@ class Variable : public Object {
 public:
     explicit Variable(std::string_view name) : Object{name} {}
 
-    auto type() const { return m_type; }
+    Type* type();
     auto type(Type* type) {
         m_type = type;
         return this;
@@ -21,7 +21,7 @@ public:
 
     // Helper that recurses though owners to find the correct type.
     auto type(std::string_view name) {
-        m_type = find_in_owners_or_add<Type>(name);
+        m_type_name = name;
         return this;
     }
 
@@ -34,9 +34,9 @@ public:
     // Sets the offset to be after the last variable in the struct.
     Variable* append();
 
-    virtual size_t size() const;
+    virtual size_t size();
 
-    auto end() const { return offset() + size(); }
+    auto end() { return offset() + size(); }
 
     auto bit_size(size_t size) {
         // assert(size <= m_type->size() * CHAR_BIT);
@@ -57,9 +57,9 @@ public:
     // Call this after append() or offset()
     Variable* bit_append();
 
-    virtual void generate(std::ostream& os) const;
-
+    virtual void generate(std::ostream& os);
 protected:
+    std::string_view m_type_name{};
     Type* m_type{};
     uintptr_t m_offset{};
     size_t m_bit_size{};

--- a/src/namespace.cpp
+++ b/src/namespace.cpp
@@ -1,3 +1,5 @@
+#include <iterator>
+#include <ranges>
 #include <sdkgenny/class.hpp>
 #include <sdkgenny/enum.hpp>
 #include <sdkgenny/enum_class.hpp>
@@ -31,5 +33,22 @@ EnumClass* Namespace::enum_class(std::string_view name) {
 }
 Namespace* Namespace::namespace_(std::string_view name) {
     return find_or_add<Namespace>(name);
+}
+
+Type* Namespace::resolve_type(std::string_view ns) {
+    auto nssplit = std::views::split(ns, std::string_view("::"));
+    auto nssplitsize = std::ranges::distance(nssplit);
+    auto last = *std::ranges::next(nssplit.begin(), nssplitsize - 1);
+    auto type = std::string_view(last.begin(), last.end());
+    auto path = nssplit | std::views::take(nssplitsize - 1);
+    Namespace* nss = topmost_owner<Namespace>();
+    if(nss == nullptr)
+        nss = this;
+
+    for(auto const& nspath : path) {
+        nss = nss->find_in_owners<Namespace>(std::string_view(nspath.begin(), nspath.end()), true);
+    }
+    
+    return nss->find_in_owners<Type>(type, true);
 }
 } // namespace sdkgenny

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1,3 +1,4 @@
+#include "sdkgenny/namespace.hpp"
 #include <climits>
 
 #include <sdkgenny/struct.hpp>
@@ -57,12 +58,20 @@ Variable* Variable::append() {
     return this;
 }
 
-size_t Variable::size() const {
-    if (m_type == nullptr) {
+Type* Variable::type() {
+    if(m_type == nullptr) {
+        m_type = m_owner->topmost_owner<Namespace>()->resolve_type(m_type_name);
+    }
+
+    return m_type;
+}
+
+size_t Variable::size() {
+    if (type() == nullptr) {
         return 0;
     }
 
-    return m_type->size();
+    return type()->size();
 }
 
 Variable* Variable::bit_append() {
@@ -89,12 +98,12 @@ Variable* Variable::bit_append() {
     return this;
 }
 
-void Variable::generate(std::ostream& os) const {
+void Variable::generate(std::ostream& os) {
     generate_comment(os);
     generate_metadata(os);
-    m_type->generate_typename_for(os, this);
+    type()->generate_typename_for(os, this);
     os << " " << usable_name();
-    m_type->generate_variable_postamble(os);
+    type()->generate_variable_postamble(os);
 
     if (m_bit_size != 0) {
         os << " : " << std::dec << m_bit_size;


### PR DESCRIPTION
Lazily resolve variable type names.

## why

The following example would not generate the correct source code since the `Bar` type is added after the variable `Foo::bar` (class `Foo` would be empty in this case):

```cpp
sdkgenny::Sdk sdk{};
auto g = sdk.global_ns();

auto fooCls = g->class_("Foo");
fooCls->variable("bar")->type("Bar"); // <- not generated due to missing definition of Bar type
auto barCls = g->class_("Bar");
```

## implementation

When declaring variables using a type name, the type name is cached and resolved lazily when needed (on generation).
The type name includes its namespace which is resolved using the `Namespace::resolve_type` function.

This allows the following example to generate the correct source code:

```cpp
sdkgenny::Sdk sdk{};
auto g = sdk.global_ns();
auto fooNs = g->namespace_("foo");
auto barNs = g->namespace_("bar");

auto fooCls = fooNs->class_("Foo");
fooCls->variable("bar")->type("bar::Bar"); // <- this type is resolved lazily at code generation

auto barCls = barNs->class_("Bar");
```

## todos

Maybe throw an exception if the type name could not be resolved ? (will implement it if wanted, wasn't sure as the current behavior is also to just ignore the missing type definition).