### PR TITLE
Added Constructor/Destructor types and static member handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 .idea
 .DS_Store
 out
-build
 cmake-build-debug
 cmake-build-release

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 SdkGenny is a library for generating C++ compatible SDKs for third party applications.
 
+## Fork purpose
+
+The creator of the sdkgenny project did not respond to my issue regarding the inability to generate static members, constructors, and destructors. This fork aims to add these features and introduce improvements, such as the ability to add initializer lists to constructors
+
 ## Installation
 
 This project uses CMake. Just get the `include/` and `src/` dirs integrated into your project in some way. The only dependency is on `PEGTL` which is only necessary if you're using the included parser.

--- a/examples/ctor_dtor_staticvar.cpp
+++ b/examples/ctor_dtor_staticvar.cpp
@@ -1,0 +1,47 @@
+#include <sdkgenny.hpp>
+#include <filesystem>
+
+using namespace sdkgenny;
+
+int main()
+{
+    // Make an SDK generator.
+    sdkgenny::Sdk sdk{};
+
+    // Get the global namespace for the SDK.
+    auto g = sdk.global_ns();
+
+    // Add some basic types to the global namespace.
+    g->type("int")->size(4);
+    g->type("float")->size(4);
+
+    // Make an actual namespace.
+    auto ns = g->namespace_("foobar");
+
+    // Make a class in the namespace.
+    auto foo = ns->class_("Foo");
+
+    // Add some members.
+    foo->variable("a")->type("int")->offset(0);
+    auto n_var = foo->variable("b")->type("float")->append();
+    n_var->initializer("10");
+
+    // Make a subclass.
+    auto bar = ns->class_("Bar")->parent(foo);
+
+    auto dtor = bar->destructor();
+    auto ctor = bar->constructor();
+    ctor->initializer_list("a(1)"); // example
+    ctor->param("test")->type(g->type("int"));
+    ctor->procedure("int a = 2");
+
+    // Use the 'as' template to perform upcasting more efficiently
+    auto var = bar->static_variable("c")->type(g->type("int")->size(4)->array_(2))->append()->as<StaticVariable>();
+    
+    // not necessary:
+    //auto static_var = (StaticVariable*)var; // upcasting
+
+    var->initializer("100");
+    sdk.generate(std::filesystem::current_path() / "usage_sdk");
+    return 0;
+}

--- a/include/sdkgenny.hpp
+++ b/include/sdkgenny.hpp
@@ -18,4 +18,7 @@
 #include <sdkgenny/type.hpp>
 #include <sdkgenny/typename.hpp>
 #include <sdkgenny/variable.hpp>
+#include <sdkgenny/static_variable.hpp>
 #include <sdkgenny/virtual_function.hpp>
+#include <sdkgenny/constructor.hpp>
+#include <sdkgenny/destructor.hpp>

--- a/include/sdkgenny/constructor.hpp
+++ b/include/sdkgenny/constructor.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <sdkgenny/function.hpp>
+#include <string>
+
+namespace sdkgenny {
+class Constructor : public Function {
+public:
+    explicit Constructor(std::string_view name);
+
+
+    void generate(std::ostream& os) const override;
+    void generate_source(std::ostream& os) const override;
+
+    // Support for initializer list: provide the raw text (e.g. "a(1), b(2)")
+    auto initializer_list() const { return m_initializer_list; }
+    auto initializer_list(std::string_view list) {
+        m_initializer_list = std::string(list);
+        return this;
+    }
+
+protected:
+    std::string m_initializer_list{};
+};
+}

--- a/include/sdkgenny/destructor.hpp
+++ b/include/sdkgenny/destructor.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <sdkgenny/function.hpp>
+
+namespace sdkgenny {
+class Destructor : public Function {
+public:
+    explicit Destructor(std::string_view name);
+    void generate(std::ostream& os) const override;
+    void generate_source(std::ostream& os) const override;
+
+    auto is_virtual() const { return m_is_virtual; }
+    auto is_virtual(bool v) {
+        m_is_virtual = v;
+        return this;
+    }
+    auto is_pure_virtual() const { return m_is_pure_virtual; }
+    auto is_pure_virtual(bool pv) {
+        m_is_pure_virtual = pv;
+        return this;
+    }
+
+protected:
+    bool m_is_virtual{};
+    bool m_is_pure_virtual{};
+};
+}

--- a/include/sdkgenny/object.hpp
+++ b/include/sdkgenny/object.hpp
@@ -185,7 +185,7 @@ public:
     // necessary.
     std::function<std::string()> usable_name = [this] {
         std::string name{};
-        constexpr auto allowed_chars = "*&[]:";
+        constexpr auto allowed_chars = "*&[]:~";
 
         for (auto&& c : m_name) {
             auto cc = static_cast<unsigned char>(c);

--- a/include/sdkgenny/sdk.hpp
+++ b/include/sdkgenny/sdk.hpp
@@ -14,6 +14,9 @@
 #include <sdkgenny/struct.hpp>
 #include <sdkgenny/type.hpp>
 #include <sdkgenny/virtual_function.hpp>
+#include <sdkgenny/variable.hpp>
+#include <sdkgenny/static_variable.hpp>
+#include <sdkgenny/constructor.hpp>
 
 namespace sdkgenny {
 class Sdk : public Object {
@@ -270,6 +273,40 @@ protected:
             os << "#include \"" << std::filesystem::relative(inc, obj->path().parent_path()).string() << "\"\n";
         }
 
+        
+        // out-of-class definitions
+        if (auto s = dynamic_cast<Struct*>(obj)) {
+            for (auto&& var : s->get_all<StaticVariable>()) {
+                // Type
+                var->type()->generate_typename_for(os, nullptr);
+                os << " ";
+
+                // Qualification with namespace/class
+                std::vector<const Object*> owners{};
+                for (auto o = obj->owner<Object>(); o != nullptr; o = o->owner<Object>()) {
+                    if (o->usable_name().empty())
+                        break;
+                    owners.emplace_back(o);
+                }
+                std::reverse(owners.begin(), owners.end());
+                for (auto&& o : owners) {
+                    os << o->usable_name() << "::";
+                }
+
+                os << obj->usable_name() << "::" << var->usable_name();
+
+                // Arrays, etc.
+                var->type()->generate_variable_postamble(os);
+
+                // writting initializer (out-of-class definitions)
+                if (!var->m_initializer.empty()) {
+                    os << " = " << var->m_initializer;
+                }
+                    
+                os << ";\n";
+            }
+        }
+
         for (auto&& fn : functions) {
             // Skip pure virtual functions.
             if (fn->is_a<VirtualFunction>() && fn->procedure().empty()) {
@@ -297,4 +334,4 @@ protected:
     }
 };
 
-} // namespace sdkgenny
+}

--- a/include/sdkgenny/static_variable.hpp
+++ b/include/sdkgenny/static_variable.hpp
@@ -1,0 +1,20 @@
+#pragma once 
+
+#include <sdkgenny/variable.hpp>
+
+namespace sdkgenny {
+	class StaticVariable : public Variable {
+	public:
+		explicit StaticVariable(std::string_view name);
+
+		void generate(std::ostream& os) const override;
+
+		auto initializer() const { return m_initializer; }
+        auto initializer(std::string_view init) { 
+			m_initializer = std::string(init);
+            return this;
+		}
+
+		std::string m_initializer{}; 
+	};
+}

--- a/include/sdkgenny/struct.hpp
+++ b/include/sdkgenny/struct.hpp
@@ -12,18 +12,26 @@
 namespace sdkgenny {
 class Variable;
 class Constant;
+class Constructor;
+class Destructor;
 class Class;
 class Enum;
 class EnumClass;
 class Function;
 class VirtualFunction;
 class StaticFunction;
+class StaticVariable;
 
 class Struct : public Type {
 public:
     explicit Struct(std::string_view name);
-
+    
+    std::string struct_name{};
+    Constructor* constructor();
+    Destructor* destructor();
     Variable* variable(std::string_view name);
+    StaticVariable* static_variable(std::string_view name);
+
     Constant* constant(std::string_view name);
 
     // Returns a map of bit_offset, bitfield_variable at a given offset. Optionally, it will ignore a given variable

--- a/include/sdkgenny/variable.hpp
+++ b/include/sdkgenny/variable.hpp
@@ -59,10 +59,17 @@ public:
 
     virtual void generate(std::ostream& os) const;
 
+    auto initializer() const { return m_initializer; }
+    auto initializer(std::string_view init) { 
+        m_initializer = std::string(init);
+        return this;
+    }
+
 protected:
     Type* m_type{};
     uintptr_t m_offset{};
     size_t m_bit_size{};
     uintptr_t m_bit_offset{};
+    std::string m_initializer{};
 };
-} // namespace sdkgenny
+}

--- a/src/constructor.cpp
+++ b/src/constructor.cpp
@@ -1,0 +1,53 @@
+#include <algorithm>
+#include <sdkgenny/constructor.hpp>
+#include <sdkgenny/detail/indent.hpp>
+
+namespace sdkgenny {
+
+Constructor::Constructor(std::string_view name) : Function{name} {
+}
+
+void Constructor::generate(std::ostream& os) const {
+    generate_comment(os);
+    generate_prototype_internal(os);
+    os << ";\n";
+}
+
+void Constructor::generate_source(std::ostream& os) const {
+    // (namespaces / enclosing types)
+    std::vector<const Object*> owners{};
+    for (auto o = owner<Object>(); o != nullptr; o = o->owner<Object>()) {
+        if (o->usable_name().empty()) {
+            break;
+        }
+        owners.emplace_back(o);
+    }
+    std::reverse(owners.begin(), owners.end());
+
+    for (auto&& o : owners) {
+        os << o->usable_name() << "::";
+    }
+    
+    generate_prototype_internal(os);
+
+
+    if (!m_initializer_list.empty()) {
+        os << " : " << m_initializer_list;
+    }
+
+    if (m_procedure.empty()) {
+        os << " {}\n";
+    } else {
+        os << " {\n";
+        {
+            detail::Indent _{os};
+            os << m_procedure;
+        }
+        if (m_procedure.back() != '\n') {
+            os << "\n";
+        }
+        os << "}\n";
+    }
+}
+
+}

--- a/src/destructor.cpp
+++ b/src/destructor.cpp
@@ -1,0 +1,70 @@
+#include <algorithm>
+#include <sdkgenny/destructor.hpp>
+#include <sdkgenny/detail/indent.hpp>
+#include <sdkgenny/parameter.hpp>
+
+namespace sdkgenny {
+
+Destructor::Destructor(std::string_view name) : Function{name} {
+}
+
+void Destructor::generate(std::ostream& os) const {
+    generate_comment(os);
+
+    if (m_is_virtual) {
+        os << "virtual ";
+    }
+
+    os << usable_name();
+    os << "(";
+    auto is_first = true;
+    for (auto&& param : get_all<Parameter>()) {
+        if (is_first)
+            is_first = false;
+        else
+            os << ", ";
+        param->generate(os);
+    }
+    os << ")";
+
+    if (m_is_virtual && m_is_pure_virtual) {
+        os << " = 0;\n";
+    } else {
+        os << ";\n";
+    }
+}
+
+void Destructor::generate_source(std::ostream& os) const {
+    if (m_is_virtual && m_is_pure_virtual) {
+        return;
+    }
+
+    std::vector<const Object*> owners{};
+    for (auto o = owner<Object>(); o != nullptr; o = o->owner<Object>()) {
+        if (o->usable_name().empty())
+            break;
+        owners.emplace_back(o);
+    }
+    std::reverse(owners.begin(), owners.end());
+
+    for (auto&& o : owners) {
+        os << o->usable_name() << "::";
+    }
+
+    generate_prototype_internal(os);
+
+    if (m_procedure.empty()) {
+        os << " {}\n";
+    } else {
+        os << " {\n";
+        {
+            detail::Indent _{os};
+            os << m_procedure;
+        }
+        if (m_procedure.back() != '\n') {
+            os << "\n";
+        }
+        os << "}\n";
+    }
+}
+}

--- a/src/static_variable.cpp
+++ b/src/static_variable.cpp
@@ -1,0 +1,24 @@
+#pragma once 
+
+#include <sdkgenny/static_variable.hpp>
+
+namespace sdkgenny {
+	StaticVariable::StaticVariable(std::string_view name) : Variable{name} {
+	}
+
+	void StaticVariable::generate(std::ostream& os) const {
+            generate_comment(os);
+            generate_metadata(os);
+
+            os << "static ";
+            m_type->generate_typename_for(os, this);
+            os << " " << usable_name();
+            m_type->generate_variable_postamble(os);
+
+            if (m_bit_size != 0) {
+                os << " : " << std::dec << m_bit_size;
+            }
+
+            os << "; // 0x" << std::hex << m_offset << "\n";
+    }
+}

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -13,16 +13,31 @@
 #include <sdkgenny/reference.hpp>
 #include <sdkgenny/static_function.hpp>
 #include <sdkgenny/variable.hpp>
+#include <sdkgenny/static_variable.hpp>
 #include <sdkgenny/virtual_function.hpp>
-
+#include <sdkgenny/constructor.hpp>
+#include <sdkgenny/destructor.hpp>
 #include <sdkgenny/struct.hpp>
 
 namespace sdkgenny {
 Struct::Struct(std::string_view name) : Type{name} {
+    struct_name = name; // necessary to generate constructor
+}
+
+Constructor* Struct::constructor() {
+    return find_or_add_unique<Constructor>(struct_name);
+}
+Destructor* Struct::destructor() {
+    return find_or_add_unique<Destructor>('~' + struct_name);
 }
 
 Variable* Struct::variable(std::string_view name) {
     return find_or_add_unique<Variable>(name);
+}
+
+StaticVariable* Struct::static_variable(std::string_view name) {
+    StaticVariable* result = find_or_add_unique<StaticVariable>(name);
+    return result;
 }
 
 Constant* Struct::constant(std::string_view name) {
@@ -359,12 +374,53 @@ void Struct::generate_internal(std::ostream& os) const {
            << "]; public:\n";
     }
 
+    /*
     if (has_any<Function>()) {
         // Generate normal functions normally.
         for (auto&& child : get_all<Function>()) {
             if (!child->is_a<VirtualFunction>()) {
                 child->generate(os);
             }
+        }
+    }*/
+
+    if (has_any<Function>()) {
+        // generating constructors, destructors, normal and static functions in order
+        std::vector<Function*> constructors;
+        std::vector<Function*> destructors;
+        std::vector<Function*> normals;
+        std::vector<Function*> statics;
+
+        for (auto&& child : get_all<Function>()) {
+            if (child->is_a<VirtualFunction>()) {
+                continue; 
+            }
+
+            if (child->is_a<Constructor>()) {
+                constructors.push_back(child);
+            } else if (child->is_a<Destructor>()){
+                destructors.push_back(child);
+            } else if (child->is_a<StaticFunction>()) {
+                statics.push_back(child);
+            } else {
+                normals.push_back(child);
+            }
+        }
+
+        for (auto&& fn : constructors) {
+            fn->generate(os);
+        }
+
+        for (auto&& fn : destructors) {
+            fn->generate(os);
+        }
+
+        for (auto&& fn : normals) {
+            fn->generate(os);
+        }
+
+        for (auto&& fn : statics) {
+            fn->generate(os);
         }
     }
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -3,6 +3,7 @@
 #include <sdkgenny/struct.hpp>
 
 #include <sdkgenny/variable.hpp>
+#include <sdkgenny/static_variable.hpp>
 
 namespace sdkgenny {
 Variable* Variable::append() {
@@ -89,6 +90,7 @@ Variable* Variable::bit_append() {
     return this;
 }
 
+/* old function
 void Variable::generate(std::ostream& os) const {
     generate_comment(os);
     generate_metadata(os);
@@ -102,4 +104,25 @@ void Variable::generate(std::ostream& os) const {
 
     os << "; // 0x" << std::hex << m_offset << "\n";
 }
-} // namespace sdkgenny
+*/
+
+void Variable::generate(std::ostream& os) const {
+    generate_comment(os);
+    generate_metadata(os);
+
+    m_type->generate_typename_for(os, this);
+    os << " " << usable_name();
+    m_type->generate_variable_postamble(os);
+
+    // For non-static members, we support inline initializers (example: int x = 5)
+    if (!m_initializer.empty()) {
+        os << " = " << m_initializer;
+    }
+
+    if (m_bit_size != 0) {
+        os << " : " << std::dec << m_bit_size;
+    }
+
+    os << "; // 0x" << std::hex << m_offset << "\n";
+}
+} 


### PR DESCRIPTION
- Added a new Constructor type with support for initializer lists and generate its definitions in the .cpp output.
- Added a new Destructor type with proper declaration/definition handling (supports virtual/pure-virtual behavior).
- Emit definitions for static data members in the generated .cpp (including array types) and support initializers.
- Ensure .cpp files are generated when constructors only have initializer lists (even without a body).
- Order member functions in Struct::generate_internal so constructors are emitted before static functions and normal functions.
- I've added a example file(ctor_dtor_staticvar.cpp) related to the improvements I made.